### PR TITLE
PX3-489 - Updates to handle g5-auth-js error on machine to machine auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,23 @@ function getBearerToken (req) {
   return bearerToken
 }
 
+function processJwtError(res, err) {
+  switch(err.name) {
+    case 'TokenExpiredError': 
+      res.status(401).send('Unauthorized')
+    break
+    default:
+      res.status(500).send(err.name)
+    break
+  }
+}
+
 function verifyToken(req, res, next) {
   const bearerToken = getBearerToken(req)
   try {
     jwt.verify(bearerToken, getKey, globalConfig.tokenSettings, function (err, decoded) {
       if (err) {
-        throw new Error(err)
+        processJwtError(res, err)
       } else {
         req.decoded = decoded
         next()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getg5/g5-auth",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getg5/g5-auth",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes Proposed:

- Added function to handle the `TokenExpiredError` when `jwt.verify` generates errors.

### Related Story:
https://teamg5.atlassian.net/browse/PX3-489

### Additional Info:
**PR's related**
https://github.com/g5search/annotation-service/pull/51
https://github.com/g5search/g5-msr/pull/21